### PR TITLE
Configure to work with heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "prestart": "npm run build",
+    "prestart:dev": "npm run build",
+    "start:dev":"node dist/run.js",
     "start": "node dist/run.js",
     "test": "jest",
     "test:watch": "npm run test -- --watch",

--- a/src/controllers/shortcode.controller.ts
+++ b/src/controllers/shortcode.controller.ts
@@ -17,8 +17,8 @@ export async function createRandomShortCode(longUrl: string): Promise<ShortCode>
 export async function createSpecificShortCode(shortCode: string, longUrl: string): Promise<ShortCode> {
     const newEntity = new ShortCode()
 
-    // check if shortCode is less than 8 chars in length 
-    if(shortCode.length > 8) {
+    // check if shortCode is less than 8 chars in length
+    if(shortCode.length >= 8) {
         throw new Error("ShortCode is too long")
     }
 

--- a/src/controllers/shortcode.controller.ts
+++ b/src/controllers/shortcode.controller.ts
@@ -18,7 +18,7 @@ export async function createSpecificShortCode(shortCode: string, longUrl: string
     const newEntity = new ShortCode()
 
     // check if shortCode is less than 8 chars in length 
-    if(shortCode.length < 8) {
+    if(shortCode.length > 8) {
         throw new Error("ShortCode is too long")
     }
 

--- a/src/db/connect.ts
+++ b/src/db/connect.ts
@@ -13,7 +13,7 @@ export const connect = async () => {
         synchronize: true,
     };
     
-    if (process.env.NODE_ENV == "production") {
+    if (process.env.NODE_ENV === "production") {
         options = {
             type: "postgres",
             url: process.env.DATABASE_URL,

--- a/src/db/connect.ts
+++ b/src/db/connect.ts
@@ -1,14 +1,28 @@
-import {createConnection, Connection} from "typeorm";
+import { createConnection, Connection, ConnectionOptions } from "typeorm";
 import { ShortCode } from "./entities/shortcode.entity";
 
-export const connect = async () => await createConnection({
-    type: "postgres",
-    username: "sclrac",
-    password: "sclrac",
-    database: "sclrac",
-    logging: "all",
-    logger: "advanced-console",
-    entities: [ ShortCode ],
-    synchronize: true,
-    // dropSchema: true, // TODO: never in production, drops tables on restart
-});
+export const connect = async () => {
+    let options: ConnectionOptions = {
+        type: "postgres",
+        username: "sclrac",
+        password: "sclrac",
+        database: "sclrac",
+        logging: "all",
+        logger: "advanced-console",
+        entities: [ShortCode],
+        synchronize: true,
+    };
+    
+    if (process.env.NODE_ENV == 'production') {
+        options = {
+            type: "postgres",
+            url: process.env.DATABASE_URL,
+            logging: "all",
+            logger: "advanced-console",
+            entities: [ShortCode],
+            synchronize: true
+        };
+    };
+
+    await createConnection(options);
+};

--- a/src/db/connect.ts
+++ b/src/db/connect.ts
@@ -13,7 +13,7 @@ export const connect = async () => {
         synchronize: true,
     };
     
-    if (process.env.NODE_ENV == 'production') {
+    if (process.env.NODE_ENV == "production") {
         options = {
             type: "postgres",
             url: process.env.DATABASE_URL,

--- a/src/db/connect.ts
+++ b/src/db/connect.ts
@@ -22,7 +22,7 @@ export const connect = async () => {
             entities: [ShortCode],
             synchronize: true
         };
-    };
+    }
 
     await createConnection(options);
 };

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import { createSpecificShortCode, getShortCodeDetails } from '../controllers/shortcode.controller'
+import { createSpecificShortCode, getShortCodeDetails, createRandomShortCode } from '../controllers/shortcode.controller'
 
 const route = Router()
 
@@ -31,7 +31,7 @@ route.post('/urls', async (req, res) => {
     // TODO: create a new shortcode entry and send the details back
     const longUrl = req.body.url
 
-    const savedShortCode = await generateRandomShortCode(longUrl)
+    const savedShortCode = await createRandomShortCode(longUrl)
 
     return res.status(201).json({ 
         status: 'success',

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,9 +5,9 @@ import { connect } from './db/connect'
 (async function start() {
 
     await connect()
-    
-    app.listen(4444, () => {
-        console.log('Server started on http://localhost:4444')
+    const env = process.env.PORT || 3000
+    app.listen(env, () => {
+        console.log(`Server started on http://localhost:${env}`)
     })
     
     

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,7 +5,7 @@ import { connect } from './db/connect'
 (async function start() {
 
     await connect()
-    const env = process.env.PORT || 3000
+    const env = process.env.PORT || 3000;
     app.listen(env, () => {
         console.log(`Server started on http://localhost:${env}`)
     })


### PR DESCRIPTION
Fixes #11 
Changes:
1. Added Procfile.
2. Modified connect.ts to createConnection with URL in production environment.
3. Modified package.json to so that prestart script only runs with npm run start:dev and not in production as 'tsc' is not recognized (typescript is a dev dependency).
4. changed run.ts to take PORT from environment variables if available.

Additional fixes:
1. Length comparison for custom shortcode was wrong
2. used the already implemented createRandomShortCode method.


